### PR TITLE
Before modification, app would not run. 'NO ACTIVE PROFILE SET' error…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.url=jdbc:mysql://localhost:3306/reactquiz
+spring.datasource.username=root
+spring.datasource.password=password
 
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
…. Added the jpa configuration to application.properties. Created the 'reactquiz' Schema manually via the mysql workbench. Will probably need to be reconfigured to handle PostgreSQL. App ran upon completion.

***EDIT***
after switching branches and reverting to a blank application.properties page, app proceeded to run on port 8080. Not sure what original issue was cause by. 